### PR TITLE
Add support for XP-Pen 22E Pro

### DIFF
--- a/src/main/kotlin/dev/villanueva/userland_utility/products/SupportedProducts.kt
+++ b/src/main/kotlin/dev/villanueva/userland_utility/products/SupportedProducts.kt
@@ -13,6 +13,8 @@ import dev.villanueva.userland_utility.products.xppen.artist_13_3_pro.Artist13_3
 import dev.villanueva.userland_utility.products.xppen.artist_13_3_pro.Artist13_3ProView
 import dev.villanueva.userland_utility.products.xppen.artist_22r_pro.Artist22rProController
 import dev.villanueva.userland_utility.products.xppen.artist_22r_pro.Artist22rProView
+import dev.villanueva.userland_utility.products.xppen.artist_22e_pro.Artist22eProController
+import dev.villanueva.userland_utility.products.xppen.artist_22e_pro.Artist22eProView
 import dev.villanueva.userland_utility.products.xppen.artist_24_pro.Artist24ProController
 import dev.villanueva.userland_utility.products.xppen.artist_24_pro.Artist24ProView
 import dev.villanueva.userland_utility.products.xppen.deco.Deco01v2Controller
@@ -66,6 +68,12 @@ object SupportedProducts {
         nameToProductIdMap[Artist22rProController.getProductName()] = Artist22rProController.getVendorProductString()
         productIdToName[Artist22rProController.getVendorProductString()] = Artist22rProController.getProductName()
         viewDeviceConfigurationMap[Artist22rProController.getProductName()] = Artist22rProView::deviceConfiguration
+
+        // XP-Pen Artist 22E Pro
+        productToClassMap[Artist22eProController.getProductName()] = Artist22eProView::class
+        nameToProductIdMap[Artist22eProController.getProductName()] = Artist22eProController.getVendorProductString()
+        productIdToName[Artist22eProController.getVendorProductString()] = Artist22eProController.getProductName()
+        viewDeviceConfigurationMap[Artist22eProController.getProductName()] = Artist22eProView::deviceConfiguration
 
         // XP-Pen Artist 24 Pro
         productToClassMap[Artist24ProController.getProductName()] = Artist24ProView::class

--- a/src/main/kotlin/dev/villanueva/userland_utility/products/xppen/artist_22e_pro/Artist22eProController.kt
+++ b/src/main/kotlin/dev/villanueva/userland_utility/products/xppen/artist_22e_pro/Artist22eProController.kt
@@ -1,0 +1,62 @@
+package dev.villanueva.userland_utility.products.xppen.artist_22e_pro
+
+import dev.villanueva.userland_utility.products.DriverCodeIDs
+import dev.villanueva.userland_utility.products.MappableItem
+import dev.villanueva.userland_utility.products.MappableItemType
+import dev.villanueva.userland_utility.products.ProductController
+import dev.villanueva.userland_utility.products.config.Configuration
+import dev.villanueva.userland_utility.products.config.DeviceConfiguration
+
+class Artist22eProController : ProductController() {
+    init {
+        mapLeftItems.add(MappableItem(MappableItemType.Button, "K1", DriverCodeIDs.BTN_0.code, 0))
+        mapLeftItems.add(MappableItem(MappableItemType.Button, "K2", DriverCodeIDs.BTN_1.code, 0))
+        mapLeftItems.add(MappableItem(MappableItemType.Button, "K3", DriverCodeIDs.BTN_2.code, 0))
+        mapLeftItems.add(MappableItem(MappableItemType.Button, "K4", DriverCodeIDs.BTN_3.code, 0))
+        mapLeftItems.add(MappableItem(MappableItemType.Button, "K5", DriverCodeIDs.BTN_4.code, 0))
+        mapLeftItems.add(MappableItem(MappableItemType.Button, "K6", DriverCodeIDs.BTN_5.code, 0))
+        mapLeftItems.add(MappableItem(MappableItemType.Button, "K7", DriverCodeIDs.BTN_6.code, 0))
+        mapLeftItems.add(MappableItem(MappableItemType.Button, "K8", DriverCodeIDs.BTN_7.code, 0))
+        mapLeftItems.add(MappableItem(MappableItemType.Button, "K9", DriverCodeIDs.BTN_8.code, 0))
+        mapLeftItems.add(MappableItem(MappableItemType.Button, "K10", DriverCodeIDs.BTN_9.code, 0))
+
+        mapRightItems.add(MappableItem(MappableItemType.Button, "K11", DriverCodeIDs.BTN_SOUTH.code, 0))
+        mapRightItems.add(MappableItem(MappableItemType.Button, "K12", DriverCodeIDs.BTN_EAST.code, 0))
+        mapRightItems.add(MappableItem(MappableItemType.Button, "K13", DriverCodeIDs.BTN_C.code, 0))
+        mapRightItems.add(MappableItem(MappableItemType.Button, "K14", DriverCodeIDs.BTN_NORTH.code, 0))
+        mapRightItems.add(MappableItem(MappableItemType.Button, "K15", DriverCodeIDs.BTN_WEST.code, 0))
+        mapRightItems.add(MappableItem(MappableItemType.Button, "K16", DriverCodeIDs.BTN_Z.code, 0))
+    }
+
+    override fun updateExistingDeviceConfig(deviceConfiguration: DeviceConfiguration): Configuration {
+        val existingConfig = Configuration.readConfig()
+        existingConfig.deviceConfigurations[getVendorIdAsString()]!![getProductIdAsString()] = deviceConfiguration
+        return existingConfig
+    }
+
+    companion object {
+        private fun getProductId(): Short {
+            return 2315
+        }
+
+        private fun getVendorId(): Short {
+            return 10429
+        }
+
+        fun getProductIdAsString(): String {
+            return getProductId().toString()
+        }
+
+        fun getVendorIdAsString(): String {
+            return getVendorId().toString()
+        }
+
+        fun getVendorProductString(): String {
+            return "${getVendorId()}:${getProductId()}"
+        }
+
+        fun getProductName(): String {
+            return "XP-Pen Artist 22E Pro"
+        }
+    }
+}

--- a/src/main/kotlin/dev/villanueva/userland_utility/products/xppen/artist_22e_pro/Artist22eProView.kt
+++ b/src/main/kotlin/dev/villanueva/userland_utility/products/xppen/artist_22e_pro/Artist22eProView.kt
@@ -1,0 +1,12 @@
+package dev.villanueva.userland_utility.products.xppen.artist_22e_pro
+
+import dev.villanueva.userland_utility.products.ProductDoubleSideShortcutsView
+
+class Artist22eProView : ProductDoubleSideShortcutsView() {
+    private val myController: Artist22eProController by inject()
+
+    init {
+        super.controller = myController
+        setup()
+    }
+}


### PR DESCRIPTION
This PR adds support for the [XP-Pen 22E Pro](https://www.xp-pen.com/product/57.html) tablet.
This tablet has 16 buttons and no wheels.