### PR TITLE
[WIP] Add support for XP-Pen Star G640S

### DIFF
--- a/src/main/kotlin/dev/villanueva/userland_utility/products/SupportedProducts.kt
+++ b/src/main/kotlin/dev/villanueva/userland_utility/products/SupportedProducts.kt
@@ -52,6 +52,8 @@ import dev.villanueva.userland_utility.products.xppen.star.StarG430SController
 import dev.villanueva.userland_utility.products.xppen.star.StarG430SView
 import dev.villanueva.userland_utility.products.xppen.star.StarG640Controller
 import dev.villanueva.userland_utility.products.xppen.star.StarG640View
+import dev.villanueva.userland_utility.products.xppen.star.StarG640SController
+import dev.villanueva.userland_utility.products.xppen.star.StarG640SView
 import kotlin.reflect.KClass
 import kotlin.reflect.KProperty1
 
@@ -187,6 +189,12 @@ object SupportedProducts {
         nameToProductIdMap[StarG640Controller.getProductName()] = StarG640Controller.getVendorProductString()
         productIdToName[StarG640Controller.getVendorProductString()] = StarG640Controller.getProductName()
         viewDeviceConfigurationMap[StarG640Controller.getProductName()] = StarG640View::deviceConfiguration
+
+        // XP-Pen Star G640S
+        productToClassMap[StarG640SController.getProductName()] = StarG640SView::class
+        nameToProductIdMap[StarG640SController.getProductName()] = StarG640SController.getVendorProductString()
+        productIdToName[StarG640SController.getVendorProductString()] = StarG640SController.getProductName()
+        viewDeviceConfigurationMap[StarG640SController.getProductName()] = StarG640SView::deviceConfiguration
 
         // XP-Pen AC19 Shortcut Remote
         productToClassMap[AC19Controller.getProductName()] = AC19View::class

--- a/src/main/kotlin/dev/villanueva/userland_utility/products/xppen/star/StarG640SController.kt
+++ b/src/main/kotlin/dev/villanueva/userland_utility/products/xppen/star/StarG640SController.kt
@@ -1,0 +1,53 @@
+package dev.villanueva.userland_utility.products.xppen.star
+
+import dev.villanueva.userland_utility.products.DriverCodeIDs
+import dev.villanueva.userland_utility.products.MappableItem
+import dev.villanueva.userland_utility.products.MappableItemType
+import dev.villanueva.userland_utility.products.ProductController
+import dev.villanueva.userland_utility.products.config.Configuration
+import dev.villanueva.userland_utility.products.config.DeviceConfiguration
+
+class StarG640SController : ProductController() {
+    init {
+        mapItems.add(MappableItem(MappableItemType.StylusButton, "Stylus 1", DriverCodeIDs.BTN_STYLUS.code, 0))
+        mapItems.add(MappableItem(MappableItemType.StylusButton, "Stylus 2", DriverCodeIDs.BTN_STYLUS2.code, 0))
+        mapItems.add(MappableItem(MappableItemType.Button, "K1", DriverCodeIDs.BTN_0.code, 0))
+        mapItems.add(MappableItem(MappableItemType.Button, "K2", DriverCodeIDs.BTN_1.code, 0))
+        mapItems.add(MappableItem(MappableItemType.Button, "K3", DriverCodeIDs.BTN_2.code, 0))
+        mapItems.add(MappableItem(MappableItemType.Button, "K4", DriverCodeIDs.BTN_3.code, 0))
+        mapItems.add(MappableItem(MappableItemType.Button, "K5", DriverCodeIDs.BTN_4.code, 0))
+        mapItems.add(MappableItem(MappableItemType.Button, "K6", DriverCodeIDs.BTN_5.code, 0))
+    }
+
+    override fun updateExistingDeviceConfig(deviceConfiguration: DeviceConfiguration): Configuration {
+        val existingConfig = Configuration.readConfig()
+        existingConfig.deviceConfigurations[getVendorIdAsString()]!![getProductIdAsString()] = deviceConfiguration
+        return existingConfig
+    }
+
+    companion object {
+        private fun getProductId(): Short {
+            return 2310
+        }
+
+        private fun getVendorId(): Short {
+            return 10429
+        }
+
+        fun getProductIdAsString(): String {
+            return getProductId().toString()
+        }
+
+        fun getVendorIdAsString(): String {
+            return getVendorId().toString()
+        }
+
+        fun getVendorProductString(): String {
+            return "${getVendorId()}:${getProductId()}"
+        }
+
+        fun getProductName(): String {
+            return "XP-Pen Star G640S"
+        }
+    }
+}

--- a/src/main/kotlin/dev/villanueva/userland_utility/products/xppen/star/StarG640SView.kt
+++ b/src/main/kotlin/dev/villanueva/userland_utility/products/xppen/star/StarG640SView.kt
@@ -1,0 +1,12 @@
+package dev.villanueva.userland_utility.products.xppen.star
+
+import dev.villanueva.userland_utility.products.ProductSingleSideShortcutsView
+
+class StarG640SView : ProductSingleSideShortcutsView() {
+    private val myController: StarG640SController by inject()
+
+    init {
+        super.controller = myController
+        setup()
+    }
+}


### PR DESCRIPTION
Product page (kind of): https://www.xp-pen.com/download/star-g640s.html

As discussed in #19 this is what I have so far. Without any changes in the daemon, it uses the generic driver, which works for the tablet buttons.

What doesn't work:
- Setting the mappings for multiple stylus buttons.

If you only set one stylus button mapping, and save, that works. I suspect it has something to do with how the config is read/written, because every time I open the gui, the stylus settings are not picked up, and doing: set stylus 1, save, set stylus 2, save; also doesn't work.